### PR TITLE
Enhancements for CDC Templates , Automated Dag Dependency Handling and TMP files removal in reporting layer

### DIFF
--- a/src/SAP/SAP_CDC/cdc_settings.yaml
+++ b/src/SAP/SAP_CDC/cdc_settings.yaml
@@ -16,6 +16,7 @@ data_to_replicate:
 {% if sql_flavour.upper() == 'S4' %}
   - base_table: acdoca
     load_frequency: "@hourly"
+    partition_flg: "Y" 
     cluster_details: {columns: ["rclnt", "rbukrs"]}
   - base_table: finsc_ld_cmp
     load_frequency: "@daily"

--- a/src/SAP/SAP_CDC/src/config_reader.py
+++ b/src/SAP/SAP_CDC/src/config_reader.py
@@ -65,7 +65,14 @@ def process_table(table_config: dict, source_dataset: str, target_dataset: str,
 
         partition_details = table_config.get("partition_details")
         cluster_details = table_config.get("cluster_details")
-
+        
+        #CUSTOM CHANGES for using the partitioning template
+        # Check for partition_flg. if it does not exist, then default the value to "N"
+        if "partition_flg" in table_config:
+            partition_flg = table_config.get("partition_flg")
+        else:
+            partition_flg = "N"
+        
         load_frequency = table_config.get("load_frequency")
         if load_frequency == "RUNTIME":
             generate_runtime_view(raw_table, cdc_table)
@@ -77,7 +84,11 @@ def process_table(table_config: dict, source_dataset: str, target_dataset: str,
             # tables.
             logging.info("Generating required files for DAG with %s ",
                          cdc_table)
-            generate_cdc_dag_files(raw_table, cdc_table, load_frequency,
+            #CUSTOM CHANGES for using partitioning template - pass the
+            # partition flag to the method
+            # generate_cdc_dag_files(raw_table, cdc_table, load_frequency,
+            #                        gen_test)
+            generate_cdc_dag_files(raw_table, cdc_table, load_frequency, partition_flg,
                                    gen_test, allow_telemetry)
 
         logging.info("✅ == Processed %s ==", raw_table)

--- a/src/SAP/SAP_CDC/src/template_sql/cdc_partition_sql_template.sql
+++ b/src/SAP/SAP_CDC/src/template_sql/cdc_partition_sql_template.sql
@@ -1,0 +1,86 @@
+--  Copyright 2021 Google Inc.
+  --  Licensed under the Apache License, Version 2.0 (the "License");
+  --  you may not use this file except in compliance with the License.
+  --  You may obtain a copy of the License at
+  --      http://www.apache.org/licenses/LICENSE-2.0
+  --  Unless required by applicable law or agreed to in writing, software
+  --  distributed under the License is distributed on an "AS IS" BASIS,
+  --  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  --  See the License for the specific language governing permissions and
+  --  limitations under the License.
+
+  -- this sql optimized template will work well for partitioned tables
+
+DECLARE max_rstamp TIMESTAMP;
+DECLARE max_raw_stamp TIMESTAMP;
+DECLARE processed_date ARRAY<DATE>;
+
+SET max_raw_stamp = TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 SECOND);
+
+SET max_rstamp = (SELECT IFNULL(MAX(recordstamp), TIMESTAMP('1940-12-25 05:30:00+00')) FROM `${target_table}`);
+
+-- NEW LOGIC FOR PROCESSED DATE
+SET processed_date = (
+ WITH
+      S01 AS (
+        SELECT * FROM `${base_table}`
+        WHERE recordstamp >= max_rstamp and recordstamp <= max_raw_stamp
+        AND ${primary_keys_not_null_clause}
+      ),
+
+      -- To handle occasional dups from SLT connector
+
+      S11 AS (
+
+        SELECT * FROM S01 QUALIFY ROW_NUMBER() 
+        OVER (  
+            PARTITION BY ${primary_keys}
+            ORDER BY recordstamp DESC,
+            IF (operation_flag = 'D', 'ZZ', operation_flag) DESC 
+        ) = 1
+        
+        -- OLD LOGIC FOR PROCESSED DATE
+        -- SELECT ${primary_keys}, recordstamp EXCEPT(row_num)
+        -- FROM (
+        --    SELECT *, ROW_NUMBER() OVER (PARTITION BY ${primary_keys} ORDER BY recordstamp desc) AS row_num
+        --   FROM S01
+        -- )
+        -- WHERE row_num = 1
+)
+
+select ARRAY_AGG(distinct date(T.recordstamp)) from `${target_table}` T inner join S11 S on  ${primary_keys_join_clause}
+);
+
+-- NEW MERGE QUERY 
+MERGE `${target_table}` AS T
+USING (
+  WITH
+    -- All the rows that arrived in raw table after the latest CDC table refresh.
+    NewRawRecords AS (
+      SELECT * FROM `${base_table}`
+      WHERE recordstamp >= max_rstamp and recordstamp <= max_raw_stamp
+      AND ${primary_keys_not_null_clause}
+    )
+    -- For each unique record (by primary key), find chronologically latest row. This ensures CDC
+    -- table only contains one entry for a unique record.
+    -- This also handles the conditions where SLT connector may have introduced true duplicate
+    -- rows (same recordstamp).
+    SELECT *
+    FROM NewRawRecords
+    QUALIFY
+      ROW_NUMBER() OVER (
+        PARTITION BY ${primary_keys}
+        ORDER BY
+          recordstamp DESC,
+          IF(operation_flag = 'D', 'ZZ', operation_flag) DESC -- Prioritize "D" flag within the dups.
+      ) = 1
+  ) AS S
+ON date(T.`recordstamp`) IN UNNEST(processed_date) AND 
+${primary_keys_join_clause}
+WHEN NOT MATCHED AND IFNULL(S.operation_flag, 'I') != 'D' THEN
+  INSERT (${fields})
+  VALUES (${fields})
+WHEN MATCHED AND S.operation_flag = 'D' THEN
+  DELETE
+WHEN MATCHED AND S.operation_flag IN ('I','U') THEN
+  UPDATE SET ${update_fields};

--- a/src/SAP/SAP_REPORTING/common/materializer/create_bq_object.py
+++ b/src/SAP/SAP_REPORTING/common/materializer/create_bq_object.py
@@ -228,6 +228,12 @@ def _generate_dag_files(module_name: str, target_dataset_type: str,
         "month": today.month,
         "day": today.day,
         "runtime_labels_dict": "", # A place holder for label dict string
+        #CUSTOM CHANGES for handling dag dependencies 
+        "table_name": table_name, 
+        "target_dataset": target_dataset,
+        "module_name": module_name,
+        "target_dataset_type": target_dataset_type
+        # CUSTOM CHANGES end of addition by Google Team for handling dag dependencies
     }
 
     # Add bq_labels to py_subs dict if telemetry allowed

--- a/src/SAP/SAP_REPORTING/common/materializer/templates/airflow_dag_template_reporting.py
+++ b/src/SAP/SAP_REPORTING/common/materializer/templates/airflow_dag_template_reporting.py
@@ -27,7 +27,105 @@ import airflow
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.google.cloud.operators.bigquery import \
     BigQueryInsertJobOperator
+#CUSTOM CHANGES - adding extra libraries for dag dependency handling 
+from airflow.sensors.external_task_sensor import ExternalTaskSensor
+import json 
+from croniter import croniter
+import pytz
 
+#read json data
+def read_json_file(filename):
+    try:
+        with open(filename, 'r') as file:
+            data = json.load(file)
+        return data
+    except FileNotFoundError:
+        print(f"Error: The file '{filename}' was not found.")
+        return None
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON format in '{filename}': {e}")
+        return None
+
+# Read file having the dependencies maintained in the data variable
+filename = '/home/airflow/gcs/data/dag-set.json'
+data = read_json_file(filename)
+
+#generate dag full name 
+def create_dag_full_name(table_name):
+
+    #please note: financial_statement_version is populating fsv_flattened table and fsv_glaccount tables both. profit_center dag is used to populate the table profitcenter_flattened
+    dag_name_exceptions = ["currency_conversion","currency_decimal","calendar_date_dim","Stock_Weekly_Snapshots_periodical_Update","Stock_Weekly_Snapshots_Initial",
+    "Stock_Monthly_Snapshots_Periodical_Update","Stock_Monthly_Snapshots_Initial", "financial_statement_version", "financial_statement_periodical_load","profit_center",
+    "Stock_Weekly_Snapshots_Update_Daily","Stock_Monthly_Snapshots_Daily_Update","Slow_Moving_Threshold","Stock_Characteristics_Config"]
+    if table_name in dag_name_exceptions:
+        return table_name
+    else:
+        dag_name = "_".join(
+            ["${target_dataset}".replace(".", "_"), "refresh", table_name])
+        dag_full_name = "_".join(
+            ["${module_name}".lower(), "${target_dataset_type}", dag_name])
+        return dag_full_name
+
+#create dependency list 
+try:
+    if data:
+        if "${table_name}" in data:
+            list_dep = data["${table_name}"]
+            c = 0
+            for i in list_dep:
+                task_id_def = "parent_task_"
+                c += 1
+                task_id_def = task_id_def + str(c)
+                dag_full_name = create_dag_full_name(i['parent_table'])
+                i.update(dag_id = dag_full_name)
+                i.update(task_id = task_id_def)
+except Exception as e: 
+    print("Exception ", e)
+
+def execution_delta_dependency(logical_date, **kwargs):
+    dt = logical_date
+    task_instance_id=str(kwargs['task_instance']).split(':')[1].split(' ')[1].split('.')[1]
+    res = None
+    try:
+        for sub in list_dep:
+            if sub['task_id'] == task_instance_id:
+                res = sub
+                break
+        
+
+        schedule_frequency=res['schedule_frequency']
+        parent_dag_poke = ''
+        print("KWARGS is ", kwargs)
+        exec_dt = kwargs['context']['execution_date']
+        print("Execution date is ", exec_dt)
+        # base = datetime(exec_dt.year, exec_dt.month, exec_dt.day, exec_dt.hour, exec_dt.minute)
+        
+        print("Logical date is ", dt)
+        iter = croniter(schedule_frequency, dt)
+        prev_instance = iter.get_prev(datetime)
+        next_instance = iter.get_next(datetime)
+        #changing parent dag poke to refer to dt if current datetime = expected dag poke time 
+        # refering logical date as the logical date is already T-1
+        print("Previous instance is ", prev_instance)
+        if next_instance == dt:
+            if not dt.tzinfo:
+                parent_dag_poke = pytz.utc.localize(dt)
+            else:
+                parent_dag_poke = dt
+        else:
+            #changing parent dag poke to refer to previous instance instead of again calculating a previous instance as the logical date is already T-1
+            if not prev_instance.tzinfo:
+                parent_dag_poke = pytz.utc.localize(prev_instance)
+            else:
+                parent_dag_poke = prev_instance
+                
+        print("Parent dag poke  ", parent_dag_poke)
+        return parent_dag_poke
+    
+    except Exception as e1: 
+        print("Exception ", e1)
+        return None
+    
 # BigQuery Job Labels - converts generated string to dict
 # If string is empty, assigns empty dict
 _BQ_LABELS = ast.literal_eval("${runtime_labels_dict}" or "{}")
@@ -47,6 +145,30 @@ with airflow.DAG("${dag_full_name}",
                  schedule_interval="${load_frequency}",
                  tags=${tags}) as dag:
     start_task = EmptyOperator(task_id="start")
+
+# add external task sensor for the dependent tasks    
+    external_task_sensors = []
+    try:
+        if list_dep:
+            for parent_task in list_dep:
+                external_task_sensor = ExternalTaskSensor(
+                    task_id=parent_task["task_id"],
+                    external_dag_id=parent_task["dag_id"],
+                    timeout=900,
+                    execution_date_fn=execution_delta_dependency,
+                    poke_interval=60,  # Check every 60 seconds
+                    mode="reschedule",  # Reschedule task if external task fails
+                    check_existence=True
+                )
+                external_task_sensors.append(external_task_sensor)
+        else:
+            no_ext_task = EmptyOperator(task_id="no_ext_task")
+            external_task_sensors.append(no_ext_task)
+    except Exception as e2:
+        print("Exception ", e2)
+        no_ext_task = EmptyOperator(task_id="no_ext_task")
+        external_task_sensors.append(no_ext_task)
+
     refresh_table = BigQueryInsertJobOperator(
             task_id="refresh_table",
             configuration={
@@ -59,4 +181,5 @@ with airflow.DAG("${dag_full_name}",
             gcp_conn_id="${lower_module_name}_${lower_tgt_dataset_type}_bq")
     stop_task = EmptyOperator(task_id="stop")
 
-    start_task >> refresh_table >> stop_task
+# add external task sensors as the dependent tasks
+    start_task >> external_task_sensors >> refresh_table >> stop_task

--- a/src/SAP/SAP_REPORTING/common/materializer/templates/dag-set.json
+++ b/src/SAP/SAP_REPORTING/common/materializer/templates/dag-set.json
@@ -1,0 +1,770 @@
+{
+    "CurrencyConversion": [
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "AccountingDocuments": [
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "CustomersMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CompaniesMD",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "AccountingDocumentsReceivable": [
+        {
+            "parent_table": "AccountingDocuments",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "InvoiceDocuments_Flow": [
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "PurchaseDocumentsHistory": [
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "AccountsPayable": [
+        {
+            "parent_table": "CurrencyConversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "VendorsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "VendorConfig",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "InvoiceDocuments_Flow",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "PurchaseDocumentsHistory",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "AccountingDocuments",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "AccountsPayableTurnover": [
+        {
+            "parent_table": "AccountsPayable",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "MaterialLedger": [
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "CashDiscountUtilization": [
+        {
+            "parent_table": "Languages_T002",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "AccountsPayable",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "PurchaseDocuments": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "POSchedule": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "VendorPerformance": [
+        {
+            "parent_table": "Languages_T002",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CurrencyConversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "PurchaseDocuments",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "POSchedule",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "PurchasingOrganizationsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "PurchasingGroupsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "PurchaseDocumentsHistory",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "VendorsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "CompaniesMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialTypesMD",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "MaterialsMovement": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "MaterialsValuation": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "Stock_NonValuated": [
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "PlantsMD",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "Stock_PerPlant": [
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "PlantsMD",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "SalesOrders_V2": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "Deliveries": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "Billing": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "PricingConditions": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "SalesOrderPricing": [
+        {
+            "parent_table": "PricingConditions",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "SalesOrderScheduleLine": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "BusinessPartnersMD": [
+        {
+            "parent_table": "AddressesMD",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "DeliveriesStatus_PerSalesOrg": [
+        {
+            "parent_table": "Deliveries",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "SDStatus_Items",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "SalesOrganizationsMD",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "OrderToCash":[
+        {
+            "parent_table": "SalesOrders",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CustomersMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "SalesOrganizationsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "DistributionChannelsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "CountriesMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "OneTouchOrder",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "DivisionsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "DeliveryBlockingReasonsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "BillingBlockingReasonsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Deliveries",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "Billing",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "POFulfillment": [
+        {
+            "parent_table": "POSchedule",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "PurchaseDocuments",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "POOrderHistory": [
+        {
+            "parent_table": "PurchaseDocuments",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "POVendorConfirmation": [
+        {
+            "parent_table": "PurchaseDocuments",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "VendorsMD",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "SalesStatus_Items": [
+        {
+            "parent_table": "SDDocumentFlow",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "SalesOrders",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "SDStatus_Items",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "SalesFulfillment": [
+        {
+            "parent_table": "SalesStatus_Items",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "SalesFulfillment_perOrder": [
+        {
+            "parent_table": "SalesStatus_Items",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "Stock_Unrestricted_vs_Sales": [
+        {
+            "parent_table": "Stock_NonValuated",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "SalesStatus_Items",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "stock_weekly_snapshots": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "stock_monthly_snapshots": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "StockMonthlySnapshots": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Languages_T002",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "Stock_Characteristics_Config",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "StorageLocationsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "PlantsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialTypesMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialGroupsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "CompaniesMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Stock_Monthly_Snapshots_Daily_Update",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "InventoryKeyMetrics": [
+        {
+            "parent_table": "Slow_Moving_Threshold",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "MaterialLedger",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "StockMonthlySnapshots",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "financial_statement_periodical_load": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "fiscal_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "FinancialStatement": [
+        {
+            "parent_table": "FSVTextsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "GLAccountsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "financial_statement_version",  
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "financial_statement_periodical_load",  
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "StockWeeklySnapshots": [
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "CompaniesMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Stock_Weekly_Snapshots_Update_Daily",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "InventoryByPlant": [
+        {
+            "parent_table": "StockWeeklySnapshots",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "Languages_T002",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialPlantsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "PlantsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "StorageLocationsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsBatchMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialTypesMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialGroupsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "MaterialLedger",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "BalanceSheet": [
+        {
+            "parent_table": "FinancialStatement",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "CompaniesMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Languages_T002",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CurrencyConversion",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "ProfitAndLoss": [
+        {
+            "parent_table": "FinancialStatement",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "CompaniesMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Languages_T002",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CurrencyConversion",
+            "schedule_frequency": "0 1 * * *"
+        }        
+    ],
+    "GrossProfitOverview": [
+        {
+            "parent_table": "ProfitAndLoss",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "NetProfitOverview": [
+        {
+            "parent_table": "GrossProfitOverview",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "ProfitAndLossOverview": [
+        {
+            "parent_table": "ProfitAndLoss",
+            "schedule_frequency": "0 2 * * *"
+        }        
+    ],
+    "DaysPayablePutstanding": [
+        {
+            "parent_table": "InventoryKeyMetrics",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "AccountsPayableTurnover",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "CurrencyConvUtil": [
+        {
+            "parent_table": "CurrencyConversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "currency_conversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "calendar_date_dim",
+            "schedule_frequency": "0 1 * * *"
+        }
+    ],
+    "CostCenterAmountsHierarchy_SAMPLE": [
+        {
+            "parent_table": "AccountingDocuments",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CostCentersMD",
+            "schedule_frequency": "0 1 * * *"
+        }        
+    ],
+    "ProfitAndLossOverview_CostCenterHierarchy": [
+        {
+            "parent_table": "CostCentersMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "ProfitAndLoss",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "CostCenterHierarchiesMD",
+            "schedule_frequency": "30 1 * * *"
+        }      
+    ],
+    "ProfitAndLossOverview_ProfitCenterHierarchy": [
+        {
+            "parent_table": "ProfitAndLoss",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "profit_center",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "ProfitCentersMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "ProfitCenterHierarchiesMD",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "SalesOrderDetails_SAMPLE": [
+        {
+            "parent_table": "SalesOrders_V2",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "Deliveries",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "Billing",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "CurrencyConversion",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "Billing",
+            "schedule_frequency": "0 2 * * *"
+        },
+        {
+            "parent_table": "CustomersMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "MaterialsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "SalesOrganizationsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "DistributionChannelsMD",
+            "schedule_frequency": "0 1 * * *"
+        },
+        {
+            "parent_table": "DivisionsMD",
+            "schedule_frequency": "30 1 * * *"
+        },
+        {
+            "parent_table": "CountriesMD",
+            "schedule_frequency": "30 1 * * *"
+        }
+    ],
+    "UoMUsage_SAMPLE": [
+        {
+            "parent_table": "SalesFulfillment",
+            "schedule_frequency": "0 2 * * *"
+        }
+    ],
+    "VendorLeadTimeOverview": [
+        {
+            "parent_table": "VendorPerformance",
+            "schedule_frequency": "0 2 * * *"
+        }        
+    ],
+    "VendorPerformanceOverview": [
+        {
+            "parent_table": "VendorPerformance",
+            "schedule_frequency": "0 2 * * *"
+        }        
+    ]
+}

--- a/src/SAP/SAP_REPORTING/common/py_libs/k9_deployer.py
+++ b/src/SAP/SAP_REPORTING/common/py_libs/k9_deployer.py
@@ -37,7 +37,7 @@ from common.py_libs import test_harness
 
 def _simple_process_and_upload(k9_id: str, k9_dir: str, jinja_dict: dict,
                               target_bucket: str, bq_client: bigquery.Client,
-                              data_source = "k9", dataset_type="processing"):
+                              data_source = "k9", dataset_type="processing", upload_tmp: bool = False):
     """Process and upload simple (traditional) K9.
 
     Recursively processes all files in k9_dir,
@@ -92,9 +92,24 @@ def _simple_process_and_upload(k9_id: str, k9_dir: str, jinja_dict: dict,
                                  f"{dataset_type}/{k9_id}")
         logging.info("Copying generated files to %s",
                      target_path)
-        subprocess.check_call([
-            "gsutil", "-m", "cp", "-r", f"{tmp_dir}/", target_path
-        ])
+         # TODO: Shift to leveraging a cloud storage client
+        gsutil_command = [
+            "gsutil",
+            "-m",
+            "cp",
+            f"{tmp_dir}/*",
+            target_path
+        ]
+        if upload_tmp:
+            gsutil_command = [
+                "gsutil",
+                "-m",
+                "cp",
+                "-r",
+                f"{tmp_dir}/",
+                target_path
+            ]
+        subprocess.check_call(gsutil_command)
 
 def load_k9s_manifest(manifest_file:str) -> dict:
     """Load K9 Manifest and format into dict.


### PR DESCRIPTION
The changes as a part of this PR contains the following 

**1. CDC Template Enhancement to include partitioning pruning**

**Description** : Enhancement added and tested to provide users an option to use an alternate template to generate the cdc merge script if their raw and cdc tables are partitioned by recordstamp field.

**Impact** : enabling and using this option, especially for performing cdc on large tables like acdoca, konv etc can significantly lower the data scans and slots used, thereby helping the customer to reduce the cost by leveraging performance optimization techniques used by bigquery

**How to use**: the users need to just mark the option partition_flg as Y to use it in their cdc settings. If this option is included with Y then this template will be used, else it will use the existing out of the box templates 

**Files changed**: 
1. src/SAP/SAP_CDC/cdc_settings.yaml
2. src/SAP/SAP_CDC/src/config_reader.py
3. src/SAP/SAP_CDC/src/generate_query.py
4. src/SAP/SAP_CDC/src/template_sql/cdc_partition_sql_template.sql (new template created)

************************************************************************************************************

**2. Automated Dynamic Dag Dependency Handling in Reporting Layer Dags**

**Problem statement** : 1:1 dags are generated for cortex semantic data models. For some data models that have dependencies, these dependencies are not captured in the dags resulting in the data loads not running as per the desired sequence that respects the parent child relationships. 

**Description**: Enhancement added to automatically include the dynamic dag dependency handling using external task sensor in the generated dags using the dag template. 

**Impact**: Saves significant efforts for the users to manually make changes to dags to include the dependencies with varying frequencies. 

**How to use** : 
1. make changes to the dag-set.json temaplate to change the frequencies and dag names as per your requirement. the frequencies here should match with the frequency in reporting settings yaml file
2. add any other custom dags in the exception list in the reporting template 
3. execute cloud build 
4. upload the dag-set.json file in data folder in composer's dag bucket 
5. copy composer dag and data files in composer's bucket
6. monitor the loads -> airflow logs for every parent task will give you the dependencies details in airflow ui

**Files changed**:
1. src/SAP/SAP_REPORTING/common/materializer/create_bq_object.py
2. src/SAP/SAP_REPORTING/common/materializer/templates/airflow_dag_template_reporting.py
3. src/SAP/SAP_REPORTING/common/materializer/templates/dag-set.json

************************************************************************************************************

**3. Remove tmp files generated for k9 during reporting layer execution**

**Description** : It is a known issue in cortex framework that temporary folders are created during cortex deployments especially for the local k9 data models

**Description of changes** : changes made to not allow creation of temporary files

**Impact** : temporary folders are not created and users do not need to manually delete the folders 
